### PR TITLE
Feature/implement driver downloading

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,24 @@
 # Nvdfetch
 Nvdfetch is a CLI application written in Go for checking for new drivers for your Nvidia GPU.
 
-There are two ways of running Nvdfetch: 
-1. Run the application with no command line arguments. This makes the application run in automatic mode, which queries the host system for the required information to find the correct drivers.
-1. Run the application with the ```-m``` argument. On initial launch, the application asks a series of questions about the host system. The answers are used to determine the correct driver to get. A config file ```config.json``` is created based on the answers and it will be used the next time the program is run.
+Running Nvdfetch:
+* Run the application with no command line arguments. This makes the application run in automatic mode, which queries the host system for the required information to find the correct drivers.
+* Using the `-m` flag starts the application in manual mode. On initial launch, the user is asked a series of questions about the host system. The answers are used to determine the correct driver to get. A config file `config.json` is created based on the answers and it will be used for sequential runs.
 
-If you want to run the first time setup again, use the ```-f``` flag.
+Other good to know arguments:
+* `-f` runs the first time setup again. Re-writes the config file.
+* `-d` downloads the driver to disk if a newer version is found
 
-# Requirements
+## Requirements
 Windows 7, 8.* or 10
 
-## Building
-Because the NVML library uses CGO, it needs to be compiled using GCC. The go tool should handle everything for you, but you need GCC to be installed and added to PATH before building Nvdfetch.
+## Installing
+The latest version can be found on the [releases page of this repository](https://github.com/mjjs/Nvdfetch/releases/latest). The application does not really need to install anything, but it is good to keep in mind that the config file and downloaded driver files are saved in the same directory where the executable is being run in.
 
-# Todo
-* Add ability to download a newer driver (manually or automatically) instead of just printing the download URL
+## Building from source
+Because the NVML library uses CGO, it needs to be compiled using GCC. The Go tool should handle everything for you, but you need GCC to be installed and added to PATH before building Nvdfetch.
+
+## Todo
+* Add simple GUI
+* Re-implement config system(?)
 * Support for other operating systems(?)

--- a/nvdfetch.go
+++ b/nvdfetch.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"os"
@@ -183,6 +184,35 @@ func parseGpuInfo(nvml nvml.API) (string, bool, bool) {
 	return gpuName, isMobile, isFermi
 }
 
+func progressBar(percentage float64) string {
+	prog := ""
+	for i := 0; i < 10; i++ {
+		if int(percentage)/10 < i {
+			s := []string{prog, "-"}
+			prog = strings.Join(s, "")
+		} else {
+			s := []string{prog, "#"}
+			prog = strings.Join(s, "")
+		}
+	}
+	return strings.Join([]string{"[", prog, "]"}, "")
+}
+
+// Print the download progress to the console
+func showProgress(remoteFileSize int64, localFile *os.File) {
+	var localFileSize int64
+
+	for remoteFileSize > localFileSize {
+		localFileInfo, err := localFile.Stat()
+		checkError(err)
+
+		localFileSize = localFileInfo.Size()
+		progressBar := progressBar(float64(localFileSize) / float64(remoteFileSize) * 100)
+
+		fmt.Printf("\r%.0f%s %s %d/%dMB", float64(localFileSize)/float64(remoteFileSize)*100, "%", progressBar, localFileSize/1000000, remoteFileSize/1000000)
+	}
+}
+
 func main() {
 	var osID, psID, pfID int
 	// Initialize the nvml library so we can query the GPU for information
@@ -195,6 +225,7 @@ func main() {
 	getCurrentDriverVersion := flag.Bool("dv", false, "Print the current version of the GPU driver and exit")
 	automaticMode := flag.Bool("a", true, "Automatically query the host system for required information to get the latest driver")
 	manualMode := flag.Bool("m", false, "Use the config file to determine the system information")
+	downloadDriver := flag.Bool("d", false, "Download the driver if a newer one is found")
 	flag.Parse()
 
 	if *firstRun {
@@ -250,7 +281,37 @@ func main() {
 
 	if currentVersionFloat < newestVersion {
 		fmt.Println("Current version", currentVersionFloat, "<<<", newestVersion, "Newest version")
-		fmt.Println(downloadURL)
+
+		if *downloadDriver {
+			// Parse the filename out of the download URL
+			filenameRegexp := regexp.MustCompile(`\d+\.\d+-.+exe`)
+			filename := filenameRegexp.FindString(downloadURL)
+
+			// Create the driver file to disk
+			driverFile, err := os.Create(filename)
+			checkError(err)
+			defer driverFile.Close()
+
+			// Get the data
+			resp, err := http.Get(downloadURL)
+			checkError(err)
+			defer resp.Body.Close()
+
+			// Get the file size of the driver
+			remoteFileSize, err := strconv.ParseInt((resp.Header.Get("Content-Length")), 0, 64)
+			checkError(err)
+
+			// Show progress of the download
+			go showProgress(remoteFileSize, driverFile)
+
+			fmt.Println("Downloading file:", filename)
+			// Write data to file
+			_, err = io.Copy(driverFile, resp.Body)
+			checkError(err)
+		} else {
+			fmt.Println(downloadURL)
+		}
+
 	} else {
 		fmt.Println("You already have the newest driver version installed:", currentVersion)
 	}


### PR DESCRIPTION
The driver can now be downloaded to disk using the `-d` command line
argument.

Also added a (naively implemented) progress bar to show the progress of
the download. Might be reworked in the future.